### PR TITLE
updating deprecated depends_on call for pylint and pyupio

### DIFF
--- a/Formula/pip-pylint.rb
+++ b/Formula/pip-pylint.rb
@@ -8,7 +8,7 @@ class PipPylint < Formula
   url 'https://pypi.python.org/packages/6c/8d/bc0b9c8ebb3ab03f6f830b1f87110291f0aef92350266a1faa4f25f0bfee/pylint-1.7.0.tar.gz'
   sha256 '27dec85ce32fe5cb78eaad11c165cfb53479ad92930783f04016eebe41f28a3a'
 
-  depends_on :python3
+  depends_on "python3"
 
   resource 'astroid' do
     url 'https://pypi.python.org/packages/64/2b/b61398454f3f64c00c88d5858d857b385c1a4dd3445f36247ba8bc74678f/astroid-1.5.1.tar.gz'

--- a/Formula/pip-pylint.rb
+++ b/Formula/pip-pylint.rb
@@ -8,7 +8,7 @@ class PipPylint < Formula
   url 'https://pypi.python.org/packages/6c/8d/bc0b9c8ebb3ab03f6f830b1f87110291f0aef92350266a1faa4f25f0bfee/pylint-1.7.0.tar.gz'
   sha256 '27dec85ce32fe5cb78eaad11c165cfb53479ad92930783f04016eebe41f28a3a'
 
-  depends_on "python3"
+  depends_on 'python3'
 
   resource 'astroid' do
     url 'https://pypi.python.org/packages/64/2b/b61398454f3f64c00c88d5858d857b385c1a4dd3445f36247ba8bc74678f/astroid-1.5.1.tar.gz'

--- a/Formula/pip-pyupio.rb
+++ b/Formula/pip-pyupio.rb
@@ -8,7 +8,7 @@ class PipPyupio < Formula
   url 'https://pypi.python.org/packages/e6/98/f837220fd644e918e54e44fd264f32e7090b6225efaf8564656859ee1564/pyupio-0.8.2.tar.gz'
   sha256 'f1f2e2ca243cdc9e7508e2482d68be428d23aa1d8d2daac9adbc6d69ad26a75d'
 
-  depends_on :python3
+  depends_on "python3"
 
   resource 'certifi' do
     url 'https://pypi.python.org/packages/20/d0/3f7a84b0c5b89e94abbd073a5f00c7176089f526edb056686751d5064cbd/certifi-2017.7.27.1.tar.gz'

--- a/Formula/pip-pyupio.rb
+++ b/Formula/pip-pyupio.rb
@@ -8,7 +8,7 @@ class PipPyupio < Formula
   url 'https://pypi.python.org/packages/e6/98/f837220fd644e918e54e44fd264f32e7090b6225efaf8564656859ee1564/pyupio-0.8.2.tar.gz'
   sha256 'f1f2e2ca243cdc9e7508e2482d68be428d23aa1d8d2daac9adbc6d69ad26a75d'
 
-  depends_on "python3"
+  depends_on 'python3'
 
   resource 'certifi' do
     url 'https://pypi.python.org/packages/20/d0/3f7a84b0c5b89e94abbd073a5f00c7176089f526edb056686751d5064cbd/certifi-2017.7.27.1.tar.gz'


### PR DESCRIPTION
Addresses #3. Thanks!